### PR TITLE
Change task name kss-index -> kssindex

### DIFF
--- a/tasks/index.js
+++ b/tasks/index.js
@@ -7,7 +7,7 @@
 
     module.exports = function(grunt) {
 
-        grunt.registerMultiTask('kss-index', 'Index KSS documented stylesheets', function() {
+        grunt.registerMultiTask('kssindex', 'Index KSS documented stylesheets', function() {
 
             var options = this.options({
                 index: null,


### PR DESCRIPTION
My linter/Grunt configuration didn't like the `-` in the task name. I suspect others might have this problem too...
